### PR TITLE
Fixed original author's misinterpretation of how ! works in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-primo-explore/custom/
+primo-explore/custom/**/css/**
+primo-explore/custom/**/html/**
+primo-explore/custom/**/img/**
+primo-explore/custom/**/js/**
 primo-explore/tmp/
 
 !primo-explore/custom/.gitignore

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -159,7 +159,7 @@ var SERVERS = {
 };
 
 /**
- * The URL to your sandbox or production Primo instance.
+ * The URL to your production Primo instance.
  * For SSL environments (https), the port number (443) must be included.
  *
  * Examples:

--- a/gulp/primoProxy.js
+++ b/gulp/primoProxy.js
@@ -187,6 +187,7 @@ module.exports.proxy_function = function () {
     var loginRewriteFlags = (config.getSaml() || config.getCas()) ? 'RL' : 'PL';
 
     return modRewrite([
+        '/view/action/(.*) ' + proxyServer + '/view/action/$1 [PL]',
         '/primo_library/libweb/webservices/rest/(.*) ' + proxyServer + '/primo_library/libweb/webservices/rest/$1 [PL]',
         '/primaws/rest/(.*) ' + proxyServer + '/primaws/rest/$1 [PL]',
         '/primo_library/libweb/primoExploreLogin ' + proxyServer + '/primo_library/libweb/primoExploreLogin [' + loginRewriteFlags + ']',

--- a/primo-explore/custom/.gitignore
+++ b/primo-explore/custom/.gitignore
@@ -1,1 +1,7 @@
 # Add entries to prefixed with '!' to unhide your view files
+# Examples (to un-gitignore a particular HTML file):
+#!IAMS_VU2/html/header.html
+# ... to un-gitignore a useful css file:
+#!IAMS_VU2/css/custom1.css
+# ... to un-gitignore ALL files in 'css' sub-directory
+#!IAMS_VU2/css/**


### PR DESCRIPTION
WIth this change it is now possible to have the GITIGNORE override work (i.e. the ! prefix) in the more deeply nested .gitignore within <proj_root>/primo-explore/custom